### PR TITLE
Don't authenticate the user when trying to revert

### DIFF
--- a/app/controllers/user_impersonate/impersonate_controller.rb
+++ b/app/controllers/user_impersonate/impersonate_controller.rb
@@ -2,7 +2,7 @@ require_dependency "user_impersonate/application_controller"
 
 module UserImpersonate
   class ImpersonateController < ApplicationController
-    before_filter :authenticate_the_user
+    before_filter :authenticate_the_user, except: ["destroy"]
     before_filter :current_user_must_be_staff!, except: ["destroy"]
 
     # Display list of all users, except current (staff) user


### PR DESCRIPTION
When reverting to the staff user, we shouldn't authenticate the current user.  We already don't check that the current user must be staff and the reason for not authenticating them before revert is the same. 

I came across this as I was enabling the `:confirmable` module for devise in my project.  If I attempted to impersonate a user that has signed up but has not confirmed their email address, then they can't log in.  So we find ourselves impersonating a user that can't authenticate.  If we try to revert to admin, then the ImpersonateController tries to authenticate the current user before reverting, which it can't, so we get a 401 and a redirect to the sign in page.  The only way out of this prison is to confirm the impersonated user's account.  
