### PR TITLE
Update #user_table to work when the table_name has been overridden

### DIFF
--- a/app/controllers/user_impersonate/impersonate_controller.rb
+++ b/app/controllers/user_impersonate/impersonate_controller.rb
@@ -115,7 +115,7 @@ module UserImpersonate
     end
 
     def user_table
-      user_class_name.tableize.tr('/', '_')
+      user_class.table_name
     end
 
     def user_id_column

--- a/test/functional/impersonate_controller_test.rb
+++ b/test/functional/impersonate_controller_test.rb
@@ -62,6 +62,15 @@ class UserImpersonate::ImpersonateControllerTest < ActionController::TestCase
     assert_equal admin_user, assigns(:current_staff)
   end
 
+  # https://github.com/rcook/user_impersonate2/issues/6
+  # Test user_table when the Class.table_name has been set or overridden
+  # to manually specify the tablename. Specifically for cases of adding namespaces
+  # to existing models or inheriting from an existing model.
+  test 'user_table should return correct table_name' do
+    User.expects(:table_name).returns("test_users")
+    assert_equal 'test_users', @controller.send(:user_table)
+  end
+
   # https://github.com/rcook/user_impersonate2/issues/3
   # If config.staff_finder is not specified, default of "find" should be used.
   # Similarly, config.staff_class should default to "User".


### PR DESCRIPTION
Fix for https://github.com/rcook/user_impersonate2/issues/6.

Using the ActiveRecord #table_name method avoids issues in cases when the table_name for a model has been set explicitly and does not match the expected pattern.