### PR TITLE
Use correct readlink in OSX

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,5 +1,10 @@
 #!/bin/bash
-SCRIPTPATH=$(readlink -f $0)
+if [[ "$OSTYPE" =~ ^darwin ]]; then
+  READLINK=greadlink
+else
+  READLINK=readlink
+fi
+SCRIPTPATH=$($READLINK -f $0)
 SCRIPTDIR=$(dirname $SCRIPTPATH)
 SCRIPTNAME=$(basename $SCRIPTPATH)
 APPDIR=$(dirname $SCRIPTDIR)
@@ -38,7 +43,7 @@ if [ "$GEMFILE" = '' ]; then
   show_usage
   exit 1
 fi
-GEMFILE=$(readlink -f $GEMFILE)
+GEMFILE=$(READLINK -f $GEMFILE)
 
 # Ensure gem dependencies are installed
 if [ $NOINSTALL -eq 0 ]; then

--- a/script/test-all
+++ b/script/test-all
@@ -1,5 +1,10 @@
 #!/bin/bash
-SCRIPTPATH=$(readlink -f $0)
+if [[ "$OSTYPE" =~ ^darwin ]]; then
+  READLINK=greadlink
+else
+  READLINK=readlink
+fi
+SCRIPTPATH=$($READLINK -f $0)
 SCRIPTDIR=$(dirname $SCRIPTPATH)
 SCRIPTNAME=$(basename $SCRIPTPATH)
 APPDIR=$(dirname $SCRIPTDIR)


### PR DESCRIPTION
When using `script/test` on OSX their is an issue with readlink

```
readlink: illegal option -- f
usage: readlink [-n] [file ...]
usage: dirname path
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
usage: dirname path
readlink: illegal option -- f
usage: readlink [-n] [file ...]
```

This fix choose the osx version of readlink : GNU readlink.