### PR TITLE
Set RAILS_ENV before running test

### DIFF
--- a/script/test
+++ b/script/test
@@ -51,10 +51,10 @@ if [ $NOINSTALL -eq 0 ]; then
 fi
 
 # Reset database
-run_bundler exec rake db:reset
+RAILS_ENV=test run_bundler exec rake db:reset
 
 # Run Minitest and Cucumber tests passing any additional arguments
-run_bundler exec rake $@
+RAILS_ENV=test run_bundler exec rake $@
 
 # Build the gem
 run_bundler exec gem build user_impersonate2.gemspec


### PR DESCRIPTION
It prevents from choosing the wrong db in test. Without `RAILS_ENV=test` :
```

EEEE.....EEEE...

Finished tests in 0.212210s, 75.3970 tests/s, 113.0955 assertions/s.

  1) Error:
UserImpersonate::DeviseHelpersTest#test_user_class_other:
ActiveRecord::StatementInvalid: Could not find table 'users'
```