### PR TITLE
Keeping params after redirect_on_revert

### DIFF
--- a/app/controllers/user_impersonate/impersonate_controller.rb
+++ b/app/controllers/user_impersonate/impersonate_controller.rb
@@ -151,9 +151,9 @@ module UserImpersonate
       redirect_to url
     end
 
-    def redirect_on_revert(impersonated_user = nil)
+    def redirect_on_revert(impersonated_user = nil, redirect_params = params)
       url = config_or_default :redirect_on_revert, root_url
-      redirect_to url
+      redirect_to url, {}.merge(redirect_params)
     end
 
     # gets overridden config value for engine, else returns default


### PR DESCRIPTION
I found an issue where I needed to keep the params form a view I was at. This patch will do that trick.