### PR TITLE
Replace deprecated devise bypass option

### DIFF
--- a/lib/user_impersonate/devise_helpers.rb
+++ b/lib/user_impersonate/devise_helpers.rb
@@ -6,18 +6,18 @@ module UserImpersonate
       # +new_user+; current user stored in +session[:staff_user_id]+
       def impersonate(new_user)
         session[:staff_user_id] = current_staff.id # 
-        sign_in new_user, bypass: true
+        bypass_sign_in new_user
       end
-      
+
       # revert the +current_user+ back to the staff user
       # stored in +session[:staff_user_id]+
       def revert_impersonate
         return unless current_staff_user
-        sign_in current_staff_user, bypass: true
+        bypass_sign_in current_staff_user
         session[:staff_user_id] = nil
       end
     end
-    
+
     module UrlHelpers
       def current_staff_user
         return unless session[:staff_user_id]


### PR DESCRIPTION
Hello 👋

Small PR to fix a warning emitted when calling `impersonate`

![image](https://user-images.githubusercontent.com/16024169/68471885-78abfb00-021f-11ea-880f-daea6339a0d5.png)

The build for ruby 2.2 fails, but this seems unrelated to this PR 🤔 